### PR TITLE
Name is slightly different when compiling in Ubuntu

### DIFF
--- a/toolchains/ubuntu/README.md
+++ b/toolchains/ubuntu/README.md
@@ -8,7 +8,7 @@ Clone the repository recursively so all the submodules are installed.
 3. Build: ```cmake --build build --config Release```.
 
 ## Install files
-Copy ```build/src/dab_plugin.so``` into ```/usr/lib/sdrpp/plugins/```.
+Copy ```build/src/libdab_plugin.so``` into ```/usr/lib/sdrpp/plugins/```.
 
 Make sure that the version of SDR++ in ```vendor/sdrplusplus``` is the same as your SDR++ installation. 
 

--- a/toolchains/ubuntu/install_packages.sh
+++ b/toolchains/ubuntu/install_packages.sh
@@ -4,4 +4,4 @@ sudo apt-get --yes install build-essential ninja-build
 sudo apt-get --yes install libglfw3-dev libopengl-dev libfftw3-dev libfftw3-single3 libvolk2-dev libzstd-dev libcpu-features-dev
 
 # install mako for volk build
-python -m pip install mako --quiet
+python3 -m pip install mako --quiet


### PR DESCRIPTION
- Name of generated plugin is a bit different than the written in the documentation
- I would force to use python3 in .sh script. I had a minor issue due to this and pip